### PR TITLE
Add option to resolve scene classes to names with MSVC RTTI

### DIFF
--- a/src/live_driving/hook.cpp
+++ b/src/live_driving/hook.cpp
@@ -1,12 +1,21 @@
 #include <spdlog/spdlog.h>
 #include <safetyhook.hpp>
+#include <rttidata.h>
 
 #include "live_driving/hook.hpp"
 #include "live_driving/util.hpp"
 
-void live_driving::create_hooks(const MODULEINFO& module_info, obs_client* obs_client, const std::unordered_map<std::string, std::string>& scene_map) {
+std::string get_class_name(const MODULEINFO& module_info, const std::uintptr_t base) {
+    const auto vft = *reinterpret_cast<std::uint8_t**>(base);
+    const auto loc = reinterpret_cast<_RTTICompleteObjectLocator*>(*reinterpret_cast<std::uintptr_t*>(vft - sizeof(void*)));
+    const auto desc = reinterpret_cast<TypeDescriptor*>(static_cast<std::uint8_t*>(module_info.lpBaseOfDll) + loc->pTypeDescriptor);
+    return std::string(desc->name + 4, std::strlen(desc->name) - 6);
+}
+
+void live_driving::create_hooks(const MODULEINFO& module_info, obs_client* obs_client, const std::unordered_map<std::string, std::string>& scene_map, bool use_rtti) {
     client = obs_client;
     map = scene_map;
+    static const auto game_module = module_info;
 
     std::vector<std::tuple<std::string, safetyhook::MidHookFn>> patterns = {
         {
@@ -24,6 +33,17 @@ void live_driving::create_hooks(const MODULEINFO& module_info, obs_client* obs_c
             }
         }
     };
+
+    if (use_rtti) {
+        patterns.insert(patterns.begin(), {
+            "89 05 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B D7",
+            [](safetyhook::Context& ctx) {
+                const auto scene_id = ctx.rcx;
+                const auto scene_name = get_class_name(game_module, ctx.rbx);
+                on_change_scene(scene_id, scene_name);
+            }
+        });
+    }
 
     for(const auto& [pattern, callback] : patterns) {
         const auto hook_target = find_pattern(
@@ -44,8 +64,12 @@ void live_driving::create_hooks(const MODULEINFO& module_info, obs_client* obs_c
     spdlog::error("No scene change function found");
 }
 
-void live_driving::on_change_scene(std::uint64_t scene_id) {
-    spdlog::info("Scene changed to {}", scene_id);
+void live_driving::on_change_scene(std::uint64_t scene_id, const std::string& scene_name) {
+    if (scene_name.empty()) {
+        spdlog::info("Scene changed to {}", scene_id);
+    } else {
+        spdlog::info("Scene changed to {} (id: {})", scene_name, scene_id);
+    }
 
     if(client == nullptr) {
         return;
@@ -53,6 +77,9 @@ void live_driving::on_change_scene(std::uint64_t scene_id) {
 
     if(const std::string key = std::to_string(scene_id); map.contains(key)) {
         client->switch_scene(map[key]);
+    }
+    else if (!scene_name.empty() && map.contains(scene_name)) {
+        client->switch_scene(map[scene_name]);
     }
     else if(map.contains("default")) {
         client->switch_scene(map["default"]);

--- a/src/live_driving/hook.hpp
+++ b/src/live_driving/hook.hpp
@@ -11,6 +11,6 @@ namespace live_driving {
     inline obs_client* client;
     inline std::unordered_map<std::string, std::string> map;
 
-    void create_hooks(const MODULEINFO& module_info, obs_client* obs_client, const std::unordered_map<std::string, std::string>& scene_map);
-    void on_change_scene(std::uint64_t scene_id);
+    void create_hooks(const MODULEINFO& module_info, obs_client* obs_client, const std::unordered_map<std::string, std::string>& scene_map, bool use_rtti);
+    void on_change_scene(std::uint64_t scene_id, const std::string& scene_name = "");
 }

--- a/src/live_driving/main.cpp
+++ b/src/live_driving/main.cpp
@@ -50,6 +50,7 @@ DWORD initialize(LPVOID param) {
 
     std::optional<live_driving::obs_client> obs_client;
     std::unordered_map<std::string, std::string> map;
+    auto use_rtti = config["use_rtti"] ? config["use_rtti"].as<bool>() : false;
 
     if(config["obs_url"]) {
         auto url = config["obs_url"].as<std::string>();
@@ -84,7 +85,7 @@ DWORD initialize(LPVOID param) {
 
         MODULEINFO module_info;
         GetModuleInformation(current_process, module_handle, &module_info, sizeof(module_info));
-        create_hooks(module_info, obs_client.has_value() ? &obs_client.value() : nullptr, map);
+        create_hooks(module_info, obs_client.has_value() ? &obs_client.value() : nullptr, map, use_rtti);
 
         if(obs_client.has_value()) {
             std::thread([&obs_client = obs_client] {

--- a/src/live_driving/util.cpp
+++ b/src/live_driving/util.cpp
@@ -20,9 +20,6 @@ std::uint8_t* live_driving::find_pattern(std::uint8_t* memory, const std::uint64
     while(i < pattern_size) {
         if(pattern[i] == '?') {
             pattern_bytes.push_back(-1);
-            if(i + 1 < pattern_size && pattern[i + 1] == '?') {
-                i++;
-            }
         }
         else {
             pattern_bytes.push_back(std::stoi(pattern.substr(i, 2), nullptr, 16));


### PR DESCRIPTION
Adds a new hook and corresponding toggle option to `live_driving.yaml`

```yaml
use_rtti: true
```

When enabled, installs a new hook which reads the class name through the RTTI Complete Object Locator.

Output with the option disabled:
```
[2025-07-26 21:51:53.802] [info] Scene changed to 63
[2025-07-26 21:51:53.842] [info] Scene changed to 64
[2025-07-26 21:51:53.873] [info] Scene changed to 66
[2025-07-26 21:51:54.051] [info] Scene changed to 2
[2025-07-26 21:51:54.123] [info] Scene changed to 54
[2025-07-26 21:51:58.887] [info] Scene changed to 53
[2025-07-26 21:52:14.140] [info] Scene changed to 57
```

Output with the option enabled:
```
[2025-07-26 21:50:48.248] [info] Scene changed to CMonitorCheckScene (id: 63)
[2025-07-26 21:50:48.285] [info] Scene changed to CPackageDownLoadScene (id: 64)
[2025-07-26 21:50:48.315] [info] Scene changed to CConfigFileVersionCheckScene (id: 66)
[2025-07-26 21:50:48.486] [info] Scene changed to CTitleDemoFlow (id: 2)
[2025-07-26 21:50:48.562] [info] Scene changed to CLogoScene (id: 54)
[2025-07-26 21:50:53.002] [info] Scene changed to CTitleScene (id: 53)
[2025-07-26 21:50:54.150] [info] Scene changed to CPlayDemoScene (id: 57)
```

It will try both scene names and IDs in the map, so it shouldn't break existing configuration if people are using IDs.

Only tested in IIDX 31 & IIDX 32, but it should gracefully fallback to other scans if this one fails.

Opt-in since it's very loosely tested. Found out about this today and thought it would be a good fit for this project. 😅 