### PR TITLE
Add SDVX コナステ training mode ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Stops recording in OBS.
 ## SOUND VOLTEX (コナステ)
 - 16 - Music Select
 - 40 - Gameplay
+- 42 - TRAINING gameplay
 - 14 - Result
 - 33 - SKILL ANALYZER select
 - 15 - SKILL ANALYZER result


### PR DESCRIPTION
The other IDs for SDVX コナステ are the same from what I've tested. I only added the ID for the new TRAINING gameplay